### PR TITLE
Disable the implicit checks, they are swallowing errors

### DIFF
--- a/src/renderer/services/accounts.ts
+++ b/src/renderer/services/accounts.ts
@@ -71,7 +71,7 @@ async function getAccountsForCredential(truelayerClientId: string, credential: C
   console.log(`[${credential.credentials_id}] Processing`);
 
   let accessToken;
-  const accounts = [];
+  const accounts: ReturnedAccount[] = []
 
   const refreshToken = await getRefreshToken(credential);
 
@@ -111,7 +111,7 @@ async function getAccountsAndCards(accessToken: string, credential: Credential):
 }
 
 async function getCards(accessToken: string, credential: Credential): Promise<ReturnedAccount[]> {
-  const returnCards = [];
+  const returnCards: ReturnedAccount[] = []
   let cards;
 
   if (credential.scopes.includes("cards")) {
@@ -139,7 +139,8 @@ async function getCards(accessToken: string, credential: Credential): Promise<Re
 }
 
 async function getAccounts(accessToken: string, credential: Credential): Promise<ReturnedAccount[]> {
-  const returnAccounts = [];
+  const returnAccounts: ReturnedAccount[] = []
+
   let accounts;
 
   if (credential.scopes.includes("accounts")) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -34,12 +34,12 @@
 
     /* Strict Type-Checking Options */
     "strict": true,                           /* Enable all strict type-checking options. */
-    // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
+    "noImplicitAny": false,                 /* Raise error on expressions and declarations with an implied 'any' type. */
     // "strictNullChecks": true,              /* Enable strict null checks. */
     // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
     // "strictBindCallApply": true,           /* Enable strict 'bind', 'call', and 'apply' methods on functions. */
     // "strictPropertyInitialization": true,  /* Enable strict checking of property initialization in classes. */
-    "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
+    "noImplicitThis": false,                /* Raise error on 'this' expressions with an implied 'any' type. */
     // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
 
     /* Additional Checks */


### PR DESCRIPTION
Run `tsc --noEmit` to see the errors